### PR TITLE
style/fix: moved exact search button to TopBar.svelte

### DIFF
--- a/src/svelteComponents/TopBar.svelte
+++ b/src/svelteComponents/TopBar.svelte
@@ -5,6 +5,8 @@
   import MdMenu from "svelte-icons/md/MdMenu.svelte";
   import { onMount } from 'svelte';
   import { setTopBarHeight } from '../stores/topBarStore.js';
+  import { SlideToggle } from "@skeletonlabs/skeleton";
+  import { createEventDispatcher } from 'svelte';
 
   export let searchQuery: string = "";
   export let onSearch: (query: string) => void;
@@ -38,6 +40,18 @@
       }
     };
   });
+
+  export let exactSearch: boolean;
+
+
+  interface ChangeEventDetail {
+    value: string; 
+  }
+
+  const dispatch = createEventDispatcher<{ change: ChangeEventDetail }>();
+  function handleChange(event: Event) {
+    dispatch('change', { value: "change" });
+  }
 </script>
 
 <div bind:this={topBarElement} class="top-bar-wrapper">
@@ -56,6 +70,14 @@
           <SearchBar {searchQuery} {onSearch} />
         </div>
       </div>
+       <div class="sort-flex">
+    <SlideToggle
+      name="exactToggle"
+      active="toggle-background"
+      bind:checked={exactSearch}
+      on:change={handleChange}
+      >Exact Search</SlideToggle
+    >
     </div>
   </AppBar>
 </div>

--- a/src/sveltePages/Home.svelte
+++ b/src/sveltePages/Home.svelte
@@ -131,7 +131,6 @@
     window.open(`/view/${itemId}`, "_blank");
   }
 
-  // Keep a reference to currentTopBarHeight
   let currentTopBarHeight: number = 0;
 
   let unsubscribe: () => void = () => {};
@@ -157,34 +156,24 @@
   }
 </script>
 
-<TopBar {searchQuery} onSearch={handleSearch} {menu}></TopBar>
+<TopBar {searchQuery} onSearch={handleSearch} {menu} bind:exactSearch on:change={() => handleSearch(searchQuery)}></TopBar>
+<!--on:change={() => handleSearch(searchQuery)}-->
 
 <div class="view-layout page-with-topbar">
   <!-- Slide out menu (contains import/export, etc.) -->
   <Menu bind:menu />
 
   <div class="sort-flex">
-    <SlideToggle
-      name="exactToggle"
-      active="toggle-background"
-      bind:checked={exactSearch}
-      on:change={() => handleSearch(searchQuery)}>Exact Search</SlideToggle
-    >
-
     <div class="simple-flex items-center">
       {#if viewMode === "list"}
-        <div class="sort-container custom-dropdown">
-          <label for="sort"></label>
-          <select
-            id="sort"
-            bind:value={sortOption}
-            on:change={handleSortChange}
-          >
-            <option value="alphabetical">A-Z</option>
-            <option value="lastAdded">Newest</option>
-            <option value="firstAdded">Oldest</option>
-          </select>
-        </div>
+      <div class="sort-container custom-dropdown">
+        <label for="sort"></label>
+        <select id="sort" bind:value={sortOption} on:change={handleSortChange}>
+          <option value="alphabetical">A-Z</option>
+          <option value="lastAdded">Newest</option>
+          <option value="firstAdded">Oldest</option>
+        </select>
+      </div>
       {/if}
 
       <SlideToggle
@@ -301,28 +290,28 @@
 </div>
 
 {#if draggingItem}
-  <Dialog
-    bind:dialog={moveDialog}
-    on:create={() => {
-      console.log("Created Modal");
-      moveDialog.showModal();
-    }}
+<Dialog
+  bind:dialog={moveDialog}
+  on:create={() => {
+    console.log("Created Modal");
+    moveDialog.showModal();
+  }}
+  on:close={() => {
+    console.log("H1");
+    showMoveDialog = false;
+  }}
+>
+  <div class="important-text text-center">
+    Move "{draggingItem.name}" to:
+  </div>
+  <MoveItem
+    itemId={draggingItem._id.toString()}
+    parentItemName={targetItemName}
+    parentItemId={targetItemId}
     on:close={() => {
-      console.log("H1");
+      console.log("H2");
       showMoveDialog = false;
-    }}
-  >
-    <div class="important-text text-center">
-      Move "{draggingItem.name}" to:
-    </div>
-    <MoveItem
-      itemId={draggingItem._id.toString()}
-      parentItemName={targetItemName}
-      parentItemId={targetItemId}
-      on:close={() => {
-        console.log("H2");
-        showMoveDialog = false;
-      }}
-    />
-  </Dialog>
+   }}
+  />
+</Dialog>
 {/if}


### PR DESCRIPTION
Exact Search toggle previosuly only appeared on the "Home" page. The code for this button has been moved to the TopBar.svelte file, which now displays the toggle on every page