### PR TITLE
feat: Update tab name with current page/item

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -27,6 +27,6 @@
     </Route>
     <Route path="/viewTemplates" component={ViewTemplates} />
     <Route path="/users" component={Users} />
+    <Route path="/utility" component={Utility} />
   </main>
-  <Route path="/utility" component={Utility} />
 </Router>

--- a/src/sveltePages/Home.svelte
+++ b/src/sveltePages/Home.svelte
@@ -34,7 +34,6 @@
 
   $: {
     if (showMoveDialog) {
-      console.log("Opening");
       moveDialog.showModal();
     }
   }
@@ -57,7 +56,6 @@
   export let menu: HTMLDialogElement;
 
   async function handleSearch(query: string) {
-    console.log("Home: Starting search operation");
     searchQuery = query;
     try {
       const response = await fetch(
@@ -74,7 +72,6 @@
       if (!response.ok) throw new Error("Failed to fetch items");
 
       const data = await response.json();
-      console.log("Home: Search completed, updating results");
       searchResults = data as IBasicItemPopulated[];
       itemCount = searchResults.length;
     } catch (err) {
@@ -108,7 +105,6 @@
   let additionalWindows: ItemWindow[] = [];
 
   function handleOpenItem(event: CustomEvent) {
-    console.log("Opening item in new window:", event.detail);
     const { id } = event.detail;
 
     // Check if the window for this item already exists
@@ -136,7 +132,7 @@
   let unsubscribe: () => void = () => {};
 
   onMount(() => {
-    console.log("Home: Component mounted");
+    document.title = "Home - AssetAtlas"
     handleSearch("");
     restoreViewMode();
     unsubscribe = topBarHeight.subscribe((value) => {
@@ -149,9 +145,6 @@
   });
 
   function handleTreeClose() {
-    console.log("H1");
-    console.log(showMoveDialog);
-    console.log("Close tree window clicked");
     toggleView();
   }
 </script>
@@ -303,11 +296,9 @@
   <Dialog
     bind:dialog={moveDialog}
     on:create={() => {
-      console.log("Created Modal");
       moveDialog.showModal();
     }}
     on:close={() => {
-      console.log("H1");
       showMoveDialog = false;
     }}
   >
@@ -319,7 +310,6 @@
       parentItemName={targetItemName}
       parentItemId={targetItemId}
       on:close={() => {
-        console.log("H2");
         showMoveDialog = false;
       }}
     />

--- a/src/sveltePages/Utility.svelte
+++ b/src/sveltePages/Utility.svelte
@@ -10,6 +10,7 @@
     import JSZip from "jszip";
     import TopBar from "../svelteComponents/TopBar.svelte";
     import Menu from "../svelteComponents/Menu.svelte";
+    import { onMount } from 'svelte';
 
   let files: FileList;
   let dialog: HTMLDialogElement;
@@ -56,7 +57,6 @@
   async function handleSelected() {
     try {
       if (!files) {
-        console.error("handle called when nothing selected.");
         return;
       }
       if (files.length >= 1) {
@@ -210,6 +210,10 @@
   }
 
   function onSearch(query: string) {}
+
+  onMount(() => {
+    document.title = "Import/Export - AssetAtlas";
+  });
 </script>
 
 <TopBar searchQuery={""} {onSearch} {menu} />

--- a/src/sveltePages/View.svelte
+++ b/src/sveltePages/View.svelte
@@ -38,7 +38,6 @@
   let showItemTree = true;
 
   function handleTreeClose() {
-    console.log("Close tree window clicked");
     showItemTree = false;
   }
 
@@ -47,9 +46,12 @@
     showItemTree = true;
   }
 
+  $: {
+    document.title = item?.name + " - AssetAtlas";
+  }
+
   async function fetchItem(id: string) {
     try {
-      console.log("Fetching item from:", `/api/items/${id}`);
       const response = await fetch(`/api/items/${id}`);
 
       if (!response.ok) {
@@ -59,18 +61,14 @@
       }
       const data: IBasicItemPopulated = await response.json();
       item = data;
-      console.log("Fetched item data:", item);
       restart();
     } catch (err) {
-      console.error("Error fetching item:", err);
       item = null;
     }
   }
 
   function handleDelete() {
     deleteDialog?.close();
-    console.log(`Item ${params.id} deleted.`);
-    // go to the home page after successful deletion
     navigate("/");
   }
 
@@ -86,14 +84,10 @@
   let additionalWindows: ItemWindow[] = [];
 
   function handleOpenItem(event: CustomEvent) {
-    console.log("Opening item in new window:", event.detail);
     const { id } = event.detail;
 
     //Dont open a new window if the item is already the main item
     if (id === params.id) {
-      console.log(
-        "Item is already displayed as main view, not opening new window",
-      );
       return;
     }
 

--- a/src/sveltePages/ViewTemplates.svelte
+++ b/src/sveltePages/ViewTemplates.svelte
@@ -16,8 +16,6 @@
 
   async function fetchTemplates() {
     try {
-      console.log("Fetching templates from:", `/api/templates/getTemplates`);
-
       const response = await fetch(`/api/templates/getTemplates`);
 
       if (!response.ok) {
@@ -28,7 +26,6 @@
 
       const data: ITemplatePopulated[] = await response.json();
       templates = data;
-      console.log("Fetched templates data:", templates);
     } catch (err) {
       console.error("Error fetching templates:", err);
       templates = [];
@@ -60,6 +57,7 @@
   }
 
   onMount(() => {
+    document.title = "Templates - AssetAtlas";
     fetchTemplates();
   });
 </script>


### PR DESCRIPTION
Updates the current tab's name to "<current page - AssetAtlas". This currently works for the following pages:
- Home Page
- CSV Import/Export Page
- Templates Page
- Selecting an item to view from home page