### PR TITLE
Fix: Seperate templates same name fix

### DIFF
--- a/migrations/20251005160056-remove_field_name_uniqueness.cjs
+++ b/migrations/20251005160056-remove_field_name_uniqueness.cjs
@@ -1,0 +1,26 @@
+module.exports = {
+  /**
+   * @param db {import('mongodb').Db}
+   * @param client {import('mongodb').MongoClient}
+   * @returns {Promise<void>}
+   */
+  async up(db, client) {
+    // TODO write your migration here.
+    // See https://github.com/seppevs/migrate-mongo/#creating-a-new-migration-script
+    // Example:
+    // await db.collection('albums').updateOne({artist: 'The Beatles'}, {$set: {blacklisted: true}});
+    await db.collection('customfields').dropIndex('fieldName_1').catch(() => {});
+  },
+
+  /**
+   * @param db {import('mongodb').Db}
+   * @param client {import('mongodb').MongoClient}
+   * @returns {Promise<void>}
+   */
+  async down(db, client) {
+    // TODO write the statements to rollback your migration (if possible)
+    // Example:
+    // await db.collection('albums').updateOne({artist: 'The Beatles'}, {$set: {blacklisted: false}});
+    await db.collection('customfields').createIndex({ fieldName: 1 }, { unique: true });
+  }
+};

--- a/src/models/customField.ts
+++ b/src/models/customField.ts
@@ -8,7 +8,7 @@ export interface ICustomField extends Document {
 }
 
 const CustomFieldSchema = new Schema<ICustomField>({
-  fieldName: { type: String, unique: true, required: true },
+  fieldName: { type: String, required: true },
   dataType: { 
     type: String, 
     required: true,

--- a/src/svelteComponents/EditTemplate.svelte
+++ b/src/svelteComponents/EditTemplate.svelte
@@ -43,6 +43,7 @@
           const createdField = await createCustomField(
             field.fieldName,
             field.dataType,
+            template._id
           );
           return createdField._id;
         }
@@ -80,11 +81,12 @@
   async function createCustomField(
     fieldName: string,
     dataType: string,
+    templateId: string
   ): Promise<ICustomField> {
     const response = await fetch(`/api/customFields`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ fieldName, dataType }),
+      body: JSON.stringify({ fieldName, dataType, templateId}),
     });
     return await response.json();
   }

--- a/src/svelteComponents/EditTemplate.svelte
+++ b/src/svelteComponents/EditTemplate.svelte
@@ -2,6 +2,7 @@
   import type { ITemplatePopulated } from "../models/template.js";
   import type { ICustomField } from "../models/customField.js";
   import CustomFieldPicker from "./CustomFieldPicker.svelte";
+    import type { Mongoose } from "mongoose";
 
   export let template: ITemplatePopulated;
   export let onClose: () => void;
@@ -43,7 +44,7 @@
           const createdField = await createCustomField(
             field.fieldName,
             field.dataType,
-            template._id
+            template._id.toString()
           );
           return createdField._id;
         }


### PR DESCRIPTION
This task, which is the reason why #143 was implemented, changes our checks so that only fields with the same name on the same template are invalid, not just fields with the same name in general. This uses the migration system to remove an index from the customfields collection as well.