### PR TITLE
Fix docker containers shutdown problems

### DIFF
--- a/docker/common-services.yml
+++ b/docker/common-services.yml
@@ -1,5 +1,5 @@
+name: common-services
 services:
-  
   app-mongoexpress:
     # Development-only interface to view the mongodb contents
     # Based on https://gist.github.com/adamelliotfields/cd49f056deab05250876286d7657dc4b
@@ -7,7 +7,7 @@ services:
     container_name: assetatlas-DEVONLY-mongodb-express
     environment:
       ME_CONFIG_OPTIONS_EDITORTHEME: "darcula"
-      ME_CONFIG_BASICAUTH_USERNAME:   "user"
-      ME_CONFIG_BASICAUTH_PASSWORD:  "password"
+      ME_CONFIG_BASICAUTH_USERNAME: "user"
+      ME_CONFIG_BASICAUTH_PASSWORD: "password"
     ports:
       - "8081:8081"

--- a/docker/docker-compose-tailscale.yml
+++ b/docker/docker-compose-tailscale.yml
@@ -34,7 +34,7 @@ services:
       - "27017:27017"
     networks:
       - default
-    healthcheck: 
+    healthcheck:
       test: echo 'db.runCommand("ping").ok' | mongosh mongo:27017/tcp
       interval: 2s
       timeout: 5s
@@ -46,7 +46,8 @@ services:
       dockerfile: ./docker/Dockerfile
     depends_on:
       - mongo
-    command: ["npx", "migrate-mongo", "up", "-f", "migrate-mongo-docker-config.cjs"]
+    command:
+      ["npx", "migrate-mongo", "up", "-f", "migrate-mongo-docker-config.cjs"]
     environment:
       MONGO_URI: mongodb://mongo:27017/assetatlas_db
 
@@ -65,6 +66,18 @@ services:
       - SYS_MODULE
     restart: unless-stopped
     network_mode: host
+
+  app-mongoexpress:
+    extends:
+      file: ./common-services.yml
+      service: app-mongoexpress
+    environment:
+      ME_CONFIG_MONGODB_SERVER: mongo
+      ME_CONFIG_MONGODB_PORT: "27017"
+    depends_on:
+      - mongo
+    networks:
+      - default
 
 volumes:
   mongo-data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - mongo-data:/data/db
     networks:
       - default
-    healthcheck: 
+    healthcheck:
       test: echo 'db.runCommand("ping").ok' | mongosh mongo:27017/tcp
       interval: 2s
       timeout: 5s
@@ -45,10 +45,11 @@ services:
       dockerfile: ./docker/Dockerfile
     depends_on:
       - mongo
-    command: ["npx", "migrate-mongo", "up", "-f", "migrate-mongo-docker-config.cjs"]
+    command:
+      ["npx", "migrate-mongo", "up", "-f", "migrate-mongo-docker-config.cjs"]
     environment:
       MONGO_URI: mongodb://mongo:27017/assetatlas_db
-  
+
   app-mongoexpress:
     extends:
       file: ./common-services.yml

--- a/start.py
+++ b/start.py
@@ -9,6 +9,7 @@ from envWriter import set_env_variable
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
+
 # Function to write Tailscale auth key to .env file inside the docker folder
 def save_auth_key():
     auth_key = auth_key_entry.get()
@@ -24,22 +25,26 @@ def save_auth_key():
     except Exception as e:
         messagebox.showerror("Error", f"Failed to save Tailscale Auth Key: {e}")
 
-def show_url_popup(url): #this is all so our popup has copy paste, basically ignore all
+
+# this is all so our popup has copy paste, basically ignore all
+def show_url_popup(url):
     popup = tk.Toplevel()
     popup.title("Service Running")
     tk.Label(popup, text="Service is running at:").pack(pady=5)
     url_entry = tk.Entry(popup, width=50)
     url_entry.pack(pady=5, padx=10)
     url_entry.insert(0, url)
-    url_entry.config(state='readonly')
-    url_entry.configure(state='normal')
-    url_entry.select_range(0, 'end')
+    url_entry.config(state="readonly")
+    url_entry.configure(state="normal")
+    url_entry.select_range(0, "end")
     url_entry.focus()
-    url_entry.configure(state='readonly')
+    url_entry.configure(state="readonly")
+
     def copy_to_clipboard():
         popup.clipboard_clear()
         popup.clipboard_append(url)
-        #messagebox.showinfo("Copied", "URL copied to clipboard!")
+        copy_button.config(text="copied!")
+
     copy_button = tk.Button(popup, text="Copy URL", command=copy_to_clipboard)
     copy_button.pack(pady=5)
     ok_button = tk.Button(popup, text="OK", command=popup.destroy)
@@ -48,28 +53,39 @@ def show_url_popup(url): #this is all so our popup has copy paste, basically ign
     popup.focus_set()
     popup.transient(root)
 
-def shutdown_docker_thread():#Why do we do this stuff in threads? docker takes a while, we want the application to still do stuff while waiting
+
+# This is done in threads since docker takes a while, and we want the application to still do stuff while waiting
+def shutdown_docker_thread():
     shutdown_button.config(state=tk.DISABLED)
     thread = threading.Thread(target=shutdown_docker)
     thread.start()
 
+
+def shutdown_containers_from_compose_file(compose_file):
+    compose_file = os.path.join(SCRIPT_DIR, "docker", compose_file)
+
+    command = ["docker-compose", "-f", compose_file, "stop"]
+
+    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = process.communicate()
+
+    if process.returncode != 0:
+        shutdown_button.config(state=tk.NORMAL)
+        messagebox.showerror("Error", f"Failed to stop Docker Containers:\n{err.decode()}")
+        return
+
+
 def shutdown_docker():
     try:
-        #only target AssetAtlas containers
+        # only target AssetAtlas containers
         command = ["docker", "compose", "ls", "--filter", "name=assetatlas", "-q"]
         running = subprocess.check_output(command).decode().strip()
-        
+
         if running:
-            compose_file = os.path.join(SCRIPT_DIR, "docker", "docker-compose-tailscale.yml")
-            command = ["docker-compose", "-f", compose_file, "stop"]
+            compose_filenames = ["docker-compose.yml", "docker-compose-tailscale.yml"]
 
-            process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            out, err = process.communicate()
-
-            if process.returncode != 0:
-                shutdown_button.config(state=tk.NORMAL)
-                messagebox.showerror("Error", f"Failed to stop Docker Containers:\n{err.decode()}")
-                return
+            for filename in compose_filenames:
+                shutdown_containers_from_compose_file(filename)
 
         shutdown_button.config(state=tk.NORMAL)
         label_status.config(text="Docker containers stopped")
@@ -78,15 +94,21 @@ def shutdown_docker():
         shutdown_button.config(state=tk.NORMAL)
         messagebox.showerror("Error", f"Unexpected error: {e}")
 
+
 def on_closing():
-    if messagebox.askyesno("Quit", "Do you want to shut down the Docker containers before exiting? (If you dont, you will need to shut the program down in docker desktop)"):
+    if messagebox.askyesno(
+        "Quit",
+        "Do you want to shut down the Docker containers before exiting? (If you dont, you will need to shut the program down in docker desktop)",
+    ):
         shutdown_docker()
     root.destroy()
+
 
 def run_docker_compose_thread(mode):
     run_button.config(state=tk.DISABLED)
     thread = threading.Thread(target=run_docker_compose, args=(mode,))
     thread.start()
+
 
 # Function to run the appropriate docker-compose command based on mode
 def run_docker_compose(mode):
@@ -102,13 +124,8 @@ def run_docker_compose(mode):
         elif mode == "tailscale":
             compose_file = os.path.join(SCRIPT_DIR, "docker", "docker-compose-tailscale.yml")
             command = ["docker-compose", "-f", compose_file, "up", "--build", "-d"]
-        elif mode == "dev":
-            compose_file = os.path.join(SCRIPT_DIR, "docker", "docker-compose.dev.yml")
-            command = ["docker-compose", "-f", compose_file, "up", "--build", "-d"]
-            url = "http://localhost:3000"
-            set_env_variable("IP", "localhost:3000", os.path.join(SCRIPT_DIR, "docker", ".env"))
 
-        #working directory to where docker-compose files are located
+        # working directory to where docker-compose files are located
         os.chdir(os.path.join(SCRIPT_DIR, "docker"))
 
         # Run the docker-compose command
@@ -127,12 +144,18 @@ def run_docker_compose(mode):
             for attempt in range(max_attempts):
                 try:
                     print(f"Attempt {attempt + 1} to get Tailscale IP...")
-                    tailscale_ip = subprocess.check_output(
-                        ["docker", "exec", "tailscale", "tailscale", "ip", "-4"]
-                    ).decode().strip()
+                    tailscale_ip = (
+                        subprocess.check_output(["docker", "exec", "tailscale", "tailscale", "ip", "-4"])
+                        .decode()
+                        .strip()
+                    )
                     if tailscale_ip:
                         print(f"Found Tailscale IP: {tailscale_ip}")
-                        set_env_variable("IP", tailscale_ip + ":3000", os.path.join(SCRIPT_DIR, "docker", ".env"))
+                        set_env_variable(
+                            "IP",
+                            tailscale_ip + ":3000",
+                            os.path.join(SCRIPT_DIR, "docker", ".env"),
+                        )
                         break
                 except subprocess.CalledProcessError as e:
                     print(f"Attempt {attempt + 1} failed: {e}")
@@ -143,7 +166,6 @@ def run_docker_compose(mode):
                 return
 
             url = f"http://{tailscale_ip}:3000"
-            
 
         show_url_popup(url)
         print(f"Service is running at {url}")
@@ -154,6 +176,7 @@ def run_docker_compose(mode):
     except Exception as e:
         run_button.config(state=tk.NORMAL)
         messagebox.showerror("Error", f"Unexpected error: {e}")
+
 
 root = tk.Tk()
 root.title("Docker Compose Launcher")
@@ -172,23 +195,26 @@ mode_var = tk.StringVar(value="local")
 tk.Label(root, text="Select Mode:").grid(row=2, column=0, padx=10, pady=10)
 local_mode_radio = tk.Radiobutton(root, text="Local Mode (localhost)", variable=mode_var, value="local")
 local_mode_radio.grid(row=2, column=1, sticky="w", padx=10, pady=10)
-tailscale_mode_radio = tk.Radiobutton(root, text="Tailscale Mode (Tailscale IP)", variable=mode_var, value="tailscale")
+tailscale_mode_radio = tk.Radiobutton(
+    root, text="Tailscale Mode (Tailscale IP)", variable=mode_var, value="tailscale"
+)
 tailscale_mode_radio.grid(row=3, column=1, sticky="w", padx=10, pady=10)
-#dev_mode_radio = tk.Radiobutton(root, text="Dev Mode (docker-compose.dev.yml)", variable=mode_var, value="dev")
-#dev_mode_radio.grid(row=4, column=1, sticky="w", padx=10, pady=10)
 
 # Button to run Docker Compose
-run_button = tk.Button(root, text="Run Docker Compose", command=lambda: run_docker_compose_thread(mode_var.get()))
+run_button = tk.Button(
+    root, text="Run Docker Compose", command=lambda: run_docker_compose_thread(mode_var.get())
+)
 run_button.grid(row=5, column=0, padx=10)
 
 progressbar = ttk.Progressbar(length=250)
 progressbar.grid(row=5, column=1, padx=10)
 
-shutdown_button = tk.Button(root, text="Shut Down Docker Containers", command=lambda: shutdown_docker_thread())
+shutdown_button = tk.Button(
+    root, text="Shut Down Docker Containers", command=lambda: shutdown_docker_thread()
+)
 shutdown_button.grid(row=6, columnspan=2, padx=10, pady=10)
 
 label_status = tk.Label(root, text="")
 label_status.grid(row=7, columnspan=2, padx=10, pady=20)
 
 root.mainloop()
-


### PR DESCRIPTION
Recent changes in our docker setup revealed an issue where shutting down our docker containers wasn't done correctly. This PR is a quick fix that adds the missing app-mongoexpress to docker-compose-tailscale.yml, and corrects the shutdown logic in start.py to shut down all assetatlas containers regardless of which compose file started them