### PR TITLE
(feat) Different title when creating item vs duplicating and editing item

### DIFF
--- a/src/lib/components/CreateItem.svelte
+++ b/src/lib/components/CreateItem.svelte
@@ -592,7 +592,11 @@
 </script>
 
 <Dialog isLarge={true} bind:dialog on:close={resetForm}>
-	<h1 id="underline-header" class="font-bold text-center">Create New Item</h1>
+	{#if duplicate}
+		<h1 id="underline-header" class="font-bold text-center">Duplicate & Edit Item</h1>
+	{:else}
+		<h1 id="underline-header" class="font-bold text-center">Create New Item</h1>
+	{/if}
 	<div class="page-component large-dialog-internal">
 		<form on:submit|preventDefault={handleCreateItem}>
 			<div class="flex flex-col space-y-4">


### PR DESCRIPTION
Change the title of the "Create New Item" pop-up to instead say "Duplicate & Edit Item" when the pop-up is opened through that option.