### PR TITLE
fix: Can add/remove an image while editing an item

### DIFF
--- a/src/lib/components/EditItem.svelte
+++ b/src/lib/components/EditItem.svelte
@@ -2,6 +2,7 @@
 	import { addToRecents } from "$lib/utility/recentItemHelper";
 	import type { ICustomField, ICustomFieldEntryInstance } from "$lib/types/customField";
 	import type { IBasicItemPopulated } from "$lib/server/db/models/basicItem.js";
+	import { uploadImage } from '$lib/utility/imageUpload.js';
 	import { actionStore } from "$lib/stores/actionStore.js";
 	import { Switch } from "@skeletonlabs/skeleton-svelte";
 	import { createEventDispatcher, onMount } from "svelte";
@@ -124,8 +125,6 @@
 	}
 
 	const dispatch = createEventDispatcher();
-
-	function resetForm() {}
 
 	async function getImage() {
 		try {
@@ -543,7 +542,8 @@
 			if (removeExistingImage) {
 				formData.append("removeImage", "true");
 			} else if (selectedImage) {
-				formData.append("image", selectedImage);
+				const filename = await uploadImage(selectedImage);
+				formData.append("image", filename);
 			}
 
 			const response = await fetch(`/api/items/${item._id}`, {
@@ -781,12 +781,10 @@
 		create={() => {}}
 		close={() => {
 			showEditTemplateDialog = false;
-			resetForm();
 		}}>
 		<CreateTemplate
 			on:close={() => {
 				showEditTemplateDialog = false;
-				resetForm();
 			}} />
 	</Dialog>
 {/if}

--- a/src/lib/components/ImageSelector.svelte
+++ b/src/lib/components/ImageSelector.svelte
@@ -29,7 +29,7 @@
 		try {
 			const response = await fetch(`/api/items/${itemId}/image`);
 			if (response.ok) {
-				imagePreview = `/api/items/${itemId}/image?t=${Date.now()}`;
+				imagePreview = `/api/items/${itemId}/image`;
 				removeExistingImage = false;
 				dispatch('imageChange', { 
 					selectedImage: null,

--- a/src/routes/api/items/[id]/+server.ts
+++ b/src/routes/api/items/[id]/+server.ts
@@ -34,20 +34,13 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 	const contentType = request.headers.get('content-type');
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	let bodyData: any;
-	let file: File | null = null;
 
 	if (contentType?.includes('multipart/form-data')) {
 		const formData = await request.formData();
 		bodyData = {};
     
 		for (const [key, value] of formData.entries()) {
-			if (key === 'file' || key === 'image') {
-				if (value instanceof File && value.size > 0) {
-					file = value;
-				}
-			} else {
-				bodyData[key] = value;
-			}
+			bodyData[key] = value;
 		}
 	} else {
 		try {
@@ -75,12 +68,6 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 
 	if (bodyData.removeImage === 'true' || bodyData.removeImage === true) {
 		item.image = undefined;
-	} else if (file) {
-		console.log('Processing uploaded file:', file);
-		const filename = await uploadImage(file);
-		if (filename) {
-			item.image = filename;
-		}
 	}
 
 	Object.assign(item, bodyData);


### PR DESCRIPTION
Closes #259 

Allows a user to add or remove images while editing an item. The problem was that the EditItem component still used old image upload logic. Now that it is updated to use tus, it seems to work without issue.