### PR TITLE
feat: Don't reset description on save + add another

### DIFF
--- a/src/lib/stores/createItemStore.svelte.ts
+++ b/src/lib/stores/createItemStore.svelte.ts
@@ -223,7 +223,6 @@ export function resetAllFields() {
 
 export function partialResetFields() {
 	_name = "";
-	_description = "";
 	_selectedImage = null;
 }
 


### PR DESCRIPTION
Tiny PR that saves item description after using the Save + Add Another button, instead of resetting that field.