### PR TITLE
Login redirects back to original page

### DIFF
--- a/src/lib/components/OAuth.svelte
+++ b/src/lib/components/OAuth.svelte
@@ -1,4 +1,4 @@
- <script lang="ts">
+<script lang="ts">
 	import { createEventDispatcher, onMount } from "svelte";
 	import { login, type LoginState } from "../stores/loginStore.js";
 
@@ -32,7 +32,7 @@
 				throw new Error(data.message || 'OAuth failed');
 			}
       
-			window.open(data.url, "_blank", "noopener,noreferrer");
+			openOAuthWindow(data.url);
       
 		} catch (err) {
 			oauthResult = err instanceof Error ? err.message : 'Something went wrong';
@@ -127,7 +127,7 @@
 				throw new Error(data.message || 'OAuth failed');
 			}
       
-			window.open(data.url, "_blank", "noopener,noreferrer");
+			openOAuthWindow(data.url);
       
 		} catch (err) {
 			oauthResult = err instanceof Error ? err.message : 'Something went wrong';
@@ -165,6 +165,19 @@
 		}
 	}
 
+	function openOAuthWindow(url: string) {
+		const width = 600;
+		const height = 700;
+		const left = window.screenX + (window.outerWidth - width) / 2;
+		const top = window.screenY + (window.outerHeight - height) / 2;
+		
+		window.open(
+			url,
+			'oauth',
+			`width=${width},height=${height},left=${left},top=${top}`
+		);
+	}
+
 
 
   
@@ -174,8 +187,16 @@
 	});
 
  
+	onMount(() => {
+		window.addEventListener('message', (event) => {
+			if (event.origin !== window.location.origin) return;
+			
+			if (event.data.type === 'oauth_success') {
+				window.location.reload();
+			}
+		});
+	});
 
-    
 </script>
 
 
@@ -238,4 +259,3 @@
 		{/if}
 	</div>
 </dialog>
-  

--- a/src/routes/api/oauth/callbackGithub/+server.ts
+++ b/src/routes/api/oauth/callbackGithub/+server.ts
@@ -69,7 +69,7 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 			maxAge: 60 * 60 * 24 * 7
 		});
 
-		throw redirect(302, '/');
+		throw redirect(302, '/oauth/success');
 	} catch (e) {
 		if (e instanceof arctic.OAuth2RequestError) {
 			throw error(400, `OAuth2 request error: ${e.message}`);

--- a/src/routes/api/oauth/callbackGoogle/+server.ts
+++ b/src/routes/api/oauth/callbackGoogle/+server.ts
@@ -75,7 +75,7 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 			maxAge: 60 * 60 * 24 * 7
 		});
 
-		throw redirect(302, '/');
+		throw redirect(302, '/oauth/success');
 	} catch (e) {
 		if (e instanceof arctic.OAuth2RequestError) {
 			throw error(400, `OAuth2 request error: ${e.message}`);

--- a/src/routes/oauth/success/+page.svelte
+++ b/src/routes/oauth/success/+page.svelte
@@ -1,0 +1,12 @@
+<script>
+    import { onMount } from 'svelte';
+    
+    onMount(() => {
+        if (window.opener) {
+            window.opener.postMessage({ type: 'oauth_success' }, window.location.origin);
+            window.close();
+        }
+    });
+</script>
+
+<p>Login successful! This window will close automatically...</p>

--- a/tests/login.test.ts
+++ b/tests/login.test.ts
@@ -274,7 +274,7 @@ describe('OAuth API', () => {
 				expect.fail('Should have thrown redirect');
 			} catch (error: any) {
 				expect(error.status).toBe(302);
-				expect(error.location).toBe('/');
+				expect(error.location).toBe('/oauth/success');
 			}
 
 			// Check auth token was set
@@ -329,7 +329,7 @@ describe('OAuth API', () => {
 				expect.fail('Should have thrown redirect');
 			} catch (error: any) {
 				expect(error.status).toBe(302);
-				expect(error.location).toBe('/');
+				expect(error.location).toBe('/oauth/success');
 			}
 
 			// Check auth token was set
@@ -374,7 +374,7 @@ describe('OAuth API', () => {
 				expect.fail('Should have thrown redirect');
 			} catch (error: any) {
 				expect(error.status).toBe(302);
-				expect(error.location).toBe('/');
+				expect(error.location).toBe('/oauth/success');
 			}
 
 			// Check auth token was set
@@ -427,7 +427,7 @@ describe('OAuth API', () => {
 				expect.fail('Should have thrown redirect');
 			} catch (error: any) {
 				expect(error.status).toBe(302);
-				expect(error.location).toBe('/');
+				expect(error.location).toBe('/oauth/success');
 			}
 
 			// Check auth token was set


### PR DESCRIPTION
Instead of opening a new tab, logging in now opens a popup for the login, and then goes back to original tab instead of opening a new one