### PR TITLE
feat: Only close item creation once success response is received

### DIFF
--- a/src/lib/components/CreateItemDesktop.svelte
+++ b/src/lib/components/CreateItemDesktop.svelte
@@ -30,7 +30,8 @@
 		setOnItemCreated,
 		resetAllFields,
 		loadAllTemplates,
-		checkIfItemExists
+		checkIfItemExists,
+		submitAndCloseItem
 	} from "$lib/stores/createItemStore.svelte";
 	import { createEventDispatcher, onMount } from "svelte";
 
@@ -87,23 +88,9 @@
 	}
 
 	setOnItemCreated(() => {
-		if (dialog) {
-			dialog.close();
-		}
 		dispatch("itemCreated");
 	});
 	initializeItemEdit();
-
-	async function submitItem() {
-		let success = await handleCreateItem();
-		if (success) {
-			if (dialog) {
-				dialog.close();
-				imageSelector.resetImage();
-				resetAllFields();
-			}
-		}
-	}
 </script>
 
 <Dialog isLarge={true} bind:dialog create={() => {}} close={resetAllFields}>
@@ -117,7 +104,7 @@
 		</h1>
 	{/if}
 	<div class="page-component large-dialog-internal">
-		<form on:submit|preventDefault={submitItem}>
+		<form on:submit|preventDefault={() => submitAndCloseItem(dialog, imageSelector)}>
 			<div class="flex flex-col space-y-4">
 				<div class="flex space-x-4">
 					<!-- Name -->

--- a/src/lib/components/CreateItemMobile.svelte
+++ b/src/lib/components/CreateItemMobile.svelte
@@ -29,7 +29,8 @@
 		setOnItemCreated,
 		resetAllFields,
 		partialResetFields,
-		checkIfItemExists
+		checkIfItemExists,
+		submitAndCloseItem
 	} from "$lib/stores/createItemStore.svelte";
 	import { createEventDispatcher } from "svelte";
 	import "$lib/styles/mobile.css";
@@ -55,17 +56,6 @@
 	});
 	initializeItemEdit();
 
-	async function submitAndClose() {
-		let success = await handleCreateItem();
-		if (success) {
-			if (dialog) {
-				dialog.close();
-			}
-			imageSelector.resetImage();
-			resetAllFields();
-		}
-	}
-
 	async function submitAndAddAnother() {
 		if (!formElement.checkValidity()) {
 			formElement.reportValidity();
@@ -89,7 +79,7 @@
 			Create New Item
 		</h1>
 	{/if}
-	<form bind:this={formElement} on:submit|preventDefault={submitAndClose}>
+	<form bind:this={formElement} on:submit|preventDefault={() => submitAndCloseItem(dialog, imageSelector)}>
 		<div class="flex flex-col space-y-4">
 			<div class="flex flex-col space-y-2">
 				<ImageSelector bind:this={imageSelector} on:imageChange={handleImageChange} />

--- a/src/lib/stores/createItemStore.svelte.ts
+++ b/src/lib/stores/createItemStore.svelte.ts
@@ -641,3 +641,18 @@ export async function checkIfItemExists(itemName: string) {
 		return false;
 	}
 }
+
+export async function submitAndCloseItem(
+	dialog: HTMLDialogElement | undefined,
+	imageSelector: { resetImage: () => void }
+) {
+	let success = await handleCreateItem();
+	if (success) {
+		if (dialog) {
+			dialog.close();
+		}
+		imageSelector.resetImage();
+		resetAllFields();
+	}
+	return success;
+}


### PR DESCRIPTION
Closes #268 

The create item dialog previously closed the moment the form was submitted. It now waits until it receives a success response from the server before closing the dialog. If no success is received or if we get an error instead, the dialog will remain open.

If you'd like to test this yourself, the easiest way to get an error response from the server is to close the tusd container then try to create an item with an image. If you check the console, it'll get stuck for a bit trying to send the request to the dead container before giving up and erroring.