### PR TITLE
fix: Dialog stays open when backing out of file chooser

### DIFF
--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -27,8 +27,7 @@
 	class="glass dialog-component self-center {isLarge
 		? 'large-dialog-noscroll'
 		: ''}"
-	bind:this={dialog}
-	oncancel={handleClose}>
+	bind:this={dialog}>
 	<button class="x-button" onclick={handleClose}>X</button>
 	{@render children?.()}
 </dialog>


### PR DESCRIPTION
Closes #257 

Previously, attempting to upload an image than cancelling it by either closing file explorer on windows or using the system back button on android would also close the create item dialog. This PR fixes that issue