### PR TITLE
feat (mobile): Prompt user to upload photo using camera

### DIFF
--- a/src/lib/components/ImageSelector.svelte
+++ b/src/lib/components/ImageSelector.svelte
@@ -13,6 +13,7 @@
 	let selectedImage: File | null = null;
   
 	const MAX_IMAGE_SIZE = 50 * 1024 * 1024; // 50MB in bytes
+	// Seems to be required for some mobile camera image submission to work https://stackoverflow.com/questions/77876374/html-input-type-file-not-working-to-pull-up-camera-for-pixel-android-14-comb
 	const allowedFileTypes = ['image/*', 'android/force-camera-workaround'];
 	const dispatch = createEventDispatcher();
 


### PR DESCRIPTION
Closes #256 

Allows users to upload a photo using their camera. This previously only worked on some devices, with some browsers. This PR should make it work everywhere, hopefully!