### PR TITLE
fix (mobile): fix mobile dialog scrolling

### DIFF
--- a/src/lib/styles/mobile.css
+++ b/src/lib/styles/mobile.css
@@ -6,8 +6,8 @@
         border: 0px;
         width: 100%;
         max-width: 100%;
-        height: 100vh;
-        max-height: 100vh;
+        height: 100dvh;
+        max-height: 100dvh;
     }
 
     body:has(dialog[open]) {


### PR DESCRIPTION
Closes #318 

The Create Item dialog was not able to scroll down far enough on some browsers on mobile. This PR fixes that by using dynamic viewport height rather than viewport height.