### PR TITLE
feat: Add Recently Changed sort option

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -239,6 +239,7 @@
 						<option value="alphabetical">A-Z</option>
 						<option value="lastAdded">Newest</option>
 						<option value="firstAdded">Oldest</option>
+						<option value="recentlyChanged">Recently Changed</option>
 					</select>
 				</div>
 			{/if}

--- a/src/routes/api/items/search/+server.ts
+++ b/src/routes/api/items/search/+server.ts
@@ -14,6 +14,8 @@ function sortItems(items: IBasicItemPopulated[], sortOption: string): IBasicItem
 				return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
 			case 'lastAdded':
 				return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+			case 'recentlyChanged':
+				return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
 			default:
 				return a.name.localeCompare(b.name);
 		}


### PR DESCRIPTION
Closes #332 

Allows users to sort items by recently changed, which sorts item by their `updatedAt` field.