### PR TITLE
feat: Require confirmation on close for create item dialog

### DIFF
--- a/src/lib/components/CreateItemDesktop.svelte
+++ b/src/lib/components/CreateItemDesktop.svelte
@@ -93,7 +93,7 @@
 	}
 </script>
 
-<Dialog canOverflow={false} isLarge={true} bind:dialog create={() => {}} close={resetAllFields}>
+<Dialog canOverflow={false} isLarge={true} bind:dialog create={() => {}} close={resetAllFields} requireCloseConfirmation={true}>
 	{#if originalItem}
 		<h1 id="underline-header" class="font-bold text-center">
 			Duplicate & Edit Item
@@ -416,7 +416,8 @@
 		create={() => {}}
 		close={() => {
 			showTemplateSelectionDialog = false;
-		}}>
+		}}
+	>
 		<div class="p-4">
 			<h2 class="font-bold text-lg mb-4">Add Template</h2>
 			<div class="flex-column flex-grow relative mb-4">

--- a/src/lib/components/CreateItemDesktop.svelte
+++ b/src/lib/components/CreateItemDesktop.svelte
@@ -103,8 +103,8 @@
 		formContainer?.scrollTo(0,0);
 		resetAllFields();
 	}}
-  requireCloseConfirmation={true}
-  >
+	requireCloseConfirmation={true}
+>
 	{#if originalItem}
 		<h1 id="underline-header" class="font-bold text-center">
 			Duplicate & Edit Item

--- a/src/lib/components/CreateItemMobile.svelte
+++ b/src/lib/components/CreateItemMobile.svelte
@@ -110,7 +110,9 @@
 	bind:dialog
 	create={() => {}}
 	isLarge={false}
-	close={resetAllFields}>
+	close={resetAllFields}
+	requireCloseConfirmation={true}
+>
 	{#if originalItem}
 		<h1 id="underline-header" class="font-bold text-center">
 			Duplicate & Edit Item

--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -28,8 +28,9 @@
 		create?.();
 	});
 
-	function handleClose() {
+	function handleClose(event: CustomEvent) {
 		if (requireCloseConfirmation) {
+			event.preventDefault();
 			closeConfirmationDialog?.showModal();
 		} else {
 			closeDialog();
@@ -44,6 +45,7 @@
 </script>
 
 <dialog
+	oncancel={handleClose}
 	class="glass dialog-component self-center {isLarge
 		? 'large-dialog-noscroll'
 		: ''}"

--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -21,24 +21,37 @@
 		requireCloseConfirmation: boolean;
 	} = $props();
 
-	let closeConfirmationDialog: HTMLDialogElement | undefined = $state(undefined);
+	let isConfirmationOpen = $state(false);
 
 	onMount(() => {
-		closeConfirmationDialog?.close();
 		create?.();
 	});
 
-	function handleClose(event: CustomEvent) {
+	function openConfirmation() {
+		isConfirmationOpen = true;
+	}
+
+	function closeConfirmation() {
+		isConfirmationOpen = false;
+	}
+
+	function handleClose(event?: Event) {
+		event?.preventDefault();
+
 		if (requireCloseConfirmation) {
-			event.preventDefault();
-			closeConfirmationDialog?.showModal();
-		} else {
-			closeDialog();
+			if (isConfirmationOpen) {
+				closeConfirmation();
+			} else {
+				openConfirmation();
+			}
+			return;
 		}
+
+		closeDialog();
 	}
 
 	function closeDialog() {
-		closeConfirmationDialog?.close();
+		closeConfirmation();
 		dialog?.close();
 		close();
 	}
@@ -53,25 +66,21 @@
 	bind:this={dialog}>
 	<button class="x-button" onclick={handleClose}>X</button>
 	{@render children?.()}
-</dialog>
-
-{#if requireCloseConfirmation}
-	<dialog
-		class="glass dialog-component self-center w-1/3 align-center"
-		closedby="any"
-		bind:this={closeConfirmationDialog}>
-		<div class="flex flex-col align-center justify-center h-full w-full">
-			<div class="important-text wrap-break-word text-center">Are you sure?</div>
-			<div class="flex justify-center gap-4">
-				<button class="flex-1 success-button font-semibold shadow mt-4" 
-					onclick={closeDialog}>
-					Exit
-				</button>
-				<button class="flex-1 warn-button font-semibold shadow mt-4" 
-					onclick={()=>{closeConfirmationDialog?.close();}}>
-					Cancel
-				</button>
+	{#if requireCloseConfirmation && isConfirmationOpen}
+		<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+			<div class="glass dialog-component self-center w-1/3 align-center">
+				<div class="flex flex-col align-center justify-center h-full w-full">
+					<div class="important-text wrap-break-word text-center">Are you sure?</div>
+					<div class="flex justify-center gap-4">
+						<button class="flex-1 success-button font-semibold shadow mt-4" onclick={closeDialog}>
+							Exit
+						</button>
+						<button class="flex-1 warn-button font-semibold shadow mt-4" onclick={closeConfirmation}>
+							Cancel
+						</button>
+					</div>
+				</div>
 			</div>
 		</div>
-	</dialog>
-{/if}
+	{/if}
+</dialog>

--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -59,6 +59,11 @@
 
 <dialog
 	oncancel={handleClose}
+	onkeydown={(event) => {
+		if (event.key === "Escape") {
+			handleClose(event);
+		}
+	}}
 	class="glass dialog-component self-center {isLarge
 		? 'large-dialog-noscroll'
 		: ''}"

--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -7,6 +7,7 @@
 		create,
 		children,
 		canOverflow = false,
+		requireCloseConfirmation = false
 	}: {
 		dialog: HTMLDialogElement | undefined;
 		isLarge: boolean;
@@ -17,13 +18,26 @@
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		children: any;
 		canOverflow: boolean;
+		requireCloseConfirmation: boolean;
 	} = $props();
 
+	let closeConfirmationDialog: HTMLDialogElement | undefined = $state(undefined);
+
 	onMount(() => {
+		closeConfirmationDialog?.close();
 		create?.();
 	});
 
 	function handleClose() {
+		if (requireCloseConfirmation) {
+			closeConfirmationDialog?.showModal();
+		} else {
+			closeDialog();
+		}
+	}
+
+	function closeDialog() {
+		closeConfirmationDialog?.close();
 		dialog?.close();
 		close();
 	}
@@ -38,3 +52,24 @@
 	<button class="x-button" onclick={handleClose}>X</button>
 	{@render children?.()}
 </dialog>
+
+{#if requireCloseConfirmation}
+	<dialog
+		class="glass dialog-component self-center w-1/3 align-center"
+		closedby="any"
+		bind:this={closeConfirmationDialog}>
+		<div class="flex flex-col align-center justify-center h-full w-full">
+			<div class="important-text wrap-break-word text-center">Are you sure?</div>
+			<div class="flex justify-center gap-4">
+				<button class="flex-1 success-button font-semibold shadow mt-4" 
+					onclick={closeDialog}>
+					Exit
+				</button>
+				<button class="flex-1 warn-button font-semibold shadow mt-4" 
+					onclick={()=>{closeConfirmationDialog?.close();}}>
+					Cancel
+				</button>
+			</div>
+		</div>
+	</dialog>
+{/if}

--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -68,7 +68,6 @@
 		? 'large-dialog-noscroll'
 		: ''}"
 	style="overflow: {canOverflow ? 'visible' : 'auto'}"
-	oncancel={handleClose}
 	bind:this={dialog}>
 	<button class="x-button" onclick={handleClose}>X</button>
 	{@render children?.()}


### PR DESCRIPTION
Closes #331

Dialogs now have the `requireCloseConfirmation` property. This is `false` by default, but when set to `true` it will prompt the user for confirmation when they try to close the dialog.

This PR sets `requireCloseConfirmation` to `true` for the CreateItem dialogs on mobile and desktop.