### PR TITLE
feat: Reset scrolling in create item dialog after closing dialog

### DIFF
--- a/src/lib/components/CreateItemDesktop.svelte
+++ b/src/lib/components/CreateItemDesktop.svelte
@@ -54,6 +54,7 @@
 	let templateSelectionDialog: HTMLDialogElement | undefined = $state();
 	let showCreateTemplateDialog = $state(false);
 	let showTemplateSelectionDialog = $state(false);
+	let formContainer: HTMLElement | undefined = $state();
 	let imageSelector: ImageSelector;
 
 	const dispatch = createEventDispatcher();
@@ -93,7 +94,15 @@
 	}
 </script>
 
-<Dialog canOverflow={false} isLarge={true} bind:dialog create={() => {}} close={resetAllFields}>
+<Dialog 
+	canOverflow={false} 
+	isLarge={true} 
+	bind:dialog 
+	create={() => {}} 
+	close={() => {
+		formContainer?.scrollTo(0,0);
+		resetAllFields();
+	}}>
 	{#if originalItem}
 		<h1 id="underline-header" class="font-bold text-center">
 			Duplicate & Edit Item
@@ -103,10 +112,11 @@
 			Create New Item
 		</h1>
 	{/if}
-	<div class="page-component large-dialog-internal">
+	<div bind:this={formContainer} class="page-component large-dialog-internal">
 		<form onsubmit={
 			(event) => {
 				event.preventDefault();
+				formContainer?.scrollTo(0,0);
 				submitAndCloseItem(dialog, imageSelector);
 			}
 		}>

--- a/src/lib/components/CreateItemMobile.svelte
+++ b/src/lib/components/CreateItemMobile.svelte
@@ -95,6 +95,7 @@
 		if (success) {
 			imageSelector.resetImage();
 			partialResetFields();
+			dialog.scrollTo(0,0);
 		}
 	}
 

--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -24,8 +24,8 @@
 	});
 
 	function handleClose() {
-		dialog?.close();
 		close();
+		dialog?.close();
 	}
 </script>
 
@@ -34,6 +34,7 @@
 		? 'large-dialog-noscroll'
 		: ''}"
 	style="overflow: {canOverflow ? 'visible' : 'auto'}"
+	oncancel={handleClose}
 	bind:this={dialog}>
 	<button class="x-button" onclick={handleClose}>X</button>
 	{@render children?.()}

--- a/tests/components/createItem.test.ts
+++ b/tests/components/createItem.test.ts
@@ -12,6 +12,13 @@ Object.defineProperty(HTMLElement.prototype, 'animate', {
 	}; },
 });
 
+Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+	value: function () { return { 
+		finished: Promise.resolve(),
+		cancel: function() {}
+	}; },
+});
+
 if (typeof HTMLDialogElement !== 'undefined') {
 	if (!HTMLDialogElement.prototype.close) {
 		HTMLDialogElement.prototype.close = vi.fn();
@@ -26,6 +33,7 @@ if (typeof HTMLDialogElement !== 'undefined') {
 		showModal = vi.fn();
 	};
 }
+
 
 
 function renderComponent(props = {}) {


### PR DESCRIPTION
I noticed that after creating an item you had to scroll back up when creating another item. Same with the "Submit and add another" button on mobile. This PR changes that so that when the dialog closes or you use the submit+add another button it resets the scroll bar to the top of the dialog.