### PR TITLE
arm64 support check

### DIFF
--- a/.github/workflows/arm-check.yml
+++ b/.github/workflows/arm-check.yml
@@ -1,0 +1,20 @@
+name: Check hosted arm64 runner
+
+on:
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: [ubuntu-22.04, arm64]
+    steps:
+      - name: Print runner and tool info
+        run: |
+          echo "--- uname -a ---"
+          uname -a
+          echo "--- uname -m ---"
+          uname -m
+          echo "--- lscpu ---"
+          lscpu || true
+          echo "--- node/npm versions ---"
+          node -v || echo "node not installed"
+          npm -v || echo "npm not installed"


### PR DESCRIPTION
Adds a temporary GitHub Action that double checks that we have access to GitHub's arm64 runners